### PR TITLE
Fixed MixinChunkBorderRenderer

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/debug/MixinChunkBorderRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/debug/MixinChunkBorderRenderer.java
@@ -16,7 +16,7 @@ public class MixinChunkBorderRenderer {
     public int minHeight(ClientLevel clientLevel) {
         Entity cameraEntity = Minecraft.getInstance().getCameraEntity();
         if (cameraEntity != null) {
-            return Coords.sectionToMinBlock(Coords.blockToCube(Coords.getCubeYForEntity(cameraEntity))) - 256;
+            return Coords.cubeToMinBlock((Coords.getCubeYForEntity(cameraEntity))) - 256;
         } else {
             return 0;
         }
@@ -26,7 +26,7 @@ public class MixinChunkBorderRenderer {
     public int maxHeight(ClientLevel clientLevel) {
         Entity cameraEntity = Minecraft.getInstance().getCameraEntity();
         if (cameraEntity != null) {
-            return Coords.sectionToMinBlock(Coords.blockToCube(Coords.getCubeYForEntity(cameraEntity))) + 256;
+            return Coords.cubeToMinBlock((Coords.getCubeYForEntity(cameraEntity))) + 256;
         } else {
             return 256;
         }


### PR DESCRIPTION
The code for getting the min and max height at which to render the chunk borders was super wack and didn't work. I have tested these changes in game and they work perfectly.

Before this change, chunk borders wouldn't render under below y = ~-256.