### PR TITLE
SurfaceTracker cleanup (WIP)

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunk/LevelCube.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunk/LevelCube.java
@@ -225,21 +225,32 @@ public class LevelCube implements ChunkAccess, CubeAccess, CubicLevelHeightAcces
         this.setAllStarts(protoCube.getAllCubeStructureStarts());
         this.setAllReferences(protoCube.getAllReferences());
 
-        this.heightmaps.putAll(protoCube.getCubeHeightmaps());
+        // copy protoCube's heightmaps
+        ChunkPos pos = this.cubePos.asChunkPos();
+        HeightmapStorage storage = ((CubicServerLevel) this.level).getHeightmapStorage();
 
-        SurfaceTrackerLeaf[] protoCubeLightHeightmaps = protoCube.getLightHeightmaps();
-        for (int localZ = 0; localZ < CubeAccess.DIAMETER_IN_SECTIONS; localZ++) {
-            for (int localX = 0; localX < CubeAccess.DIAMETER_IN_SECTIONS; localX++) {
-                int i = localX + localZ * CubeAccess.DIAMETER_IN_SECTIONS;
+        for (int sectionX = 0; sectionX < CubeAccess.DIAMETER_IN_SECTIONS; sectionX++) {
+            for (int sectionZ = 0; sectionZ < CubeAccess.DIAMETER_IN_SECTIONS; sectionZ++) {
 
-                this.lightHeightmaps[i] = protoCubeLightHeightmaps[i];
-                if (this.lightHeightmaps[i] == null) {
-                    System.out.println("Got a null light heightmap while upgrading from CubePrimer at " + this.cubePos);
-                } else {
-                    this.lightHeightmaps[i].loadCube(localX, localZ, ((CubicServerLevel) this.level).getHeightmapStorage(), this);
+                LevelChunk chunk = this.level.getChunk(pos.x + sectionX, pos.z + sectionZ);
+                int heightmapIndex = sectionX + sectionZ * DIAMETER_IN_SECTIONS;
+
+                // promote the ProtoCube's vanilla heightmaps for this chunk
+                for (Map.Entry<Heightmap.Types, Heightmap>  entry : chunk.getHeightmaps()) {
+                    SurfaceTrackerWrapper wrapper = (SurfaceTrackerWrapper) entry.getValue();
+                    SurfaceTrackerLeaf protoLeaf = protoCube.getCubeHeightmaps().get(entry.getKey())[heightmapIndex];
+                    SurfaceTrackerLeaf levelLeaf = wrapper.loadCube(storage, this, protoLeaf);
+                    sectionLoaded(levelLeaf, sectionX, sectionZ);
                 }
+
+                // promote the ProtoCube's light heightmap for this chunk
+                SurfaceTrackerWrapper lightWrapper = (SurfaceTrackerWrapper) ((LightHeightmapGetter) chunk).getLightHeightmap();
+                SurfaceTrackerLeaf lightProtoLeaf = protoCube.getLightHeightmaps()[heightmapIndex];
+                SurfaceTrackerLeaf lightLevelLeaf = lightWrapper.loadCube(storage, this, lightProtoLeaf);
+                sectionLoaded(lightLevelLeaf, sectionX, sectionZ);
             }
         }
+
         this.setCubeLight(protoCube.hasCubeLight());
         this.dirty = true;
     }
@@ -1090,28 +1101,10 @@ public class LevelCube implements ChunkAccess, CubeAccess, CubicLevelHeightAcces
     }
 
     public void postLoad() {
+
         if (this.postLoad != null) {
             this.postLoad.accept(this);
             this.postLoad = null;
-        }
-        // TODO heightmap stuff should probably be elsewhere rather than here.
-        ChunkPos pos = this.cubePos.asChunkPos();
-        HeightmapStorage storage = ((CubicServerLevel) this.level).getHeightmapStorage();
-        for (int x = 0; x < CubeAccess.DIAMETER_IN_SECTIONS; x++) {
-            for (int z = 0; z < CubeAccess.DIAMETER_IN_SECTIONS; z++) {
-
-                // This force-loads the column, but it shouldn't matter if column-cube load order is working properly.
-                LevelChunk chunk = this.level.getChunk(pos.x + x, pos.z + z);
-                ((ColumnCubeMapGetter) chunk).getCubeMap().markLoaded(this.cubePos.getY());
-                for (Map.Entry<Heightmap.Types, Heightmap> entry : chunk.getHeightmaps()) {
-                    Heightmap heightmap = entry.getValue();
-                    SurfaceTrackerWrapper tracker = (SurfaceTrackerWrapper) heightmap;
-                    tracker.loadCube(storage, this);
-                }
-
-                // TODO probably don't want to do this if the cube was already loaded as a CubePrimer
-                ((LightHeightmapGetter) chunk).getServerLightHeightmap().loadCube(storage, this);
-            }
         }
     }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunk/ProtoCube.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunk/ProtoCube.java
@@ -225,7 +225,12 @@ public class ProtoCube extends ProtoChunk implements CubeAccess, CubicLevelHeigh
                 }
 
                 SurfaceTrackerLeaf lightLeaf = lightHeightmap.loadCube(((CubicServerLevel) this.levelHeightAccessor).getHeightmapStorage(), this, null);
-                sectionLoaded(lightLeaf, dx, dz);
+                int heightmapIndex = dx + dz * DIAMETER_IN_SECTIONS;
+
+                if (lightLeaf == null)
+                    System.out.println("!");
+
+                this.lightHeightmaps[heightmapIndex] = lightLeaf;
 
                 for (int z = 0; z < SECTION_DIAMETER; z++) {
                     for (int x = 0; x < SECTION_DIAMETER; x++) {
@@ -238,19 +243,6 @@ public class ProtoCube extends ProtoChunk implements CubeAccess, CubicLevelHeigh
                     }
                 }
             }
-        }
-    }
-
-    @Override
-    public void sectionLoaded(@Nonnull SurfaceTrackerLeaf surfaceTrackerLeaf, int localSectionX, int localSectionZ) {
-        int idx = localSectionX + localSectionZ * DIAMETER_IN_SECTIONS;
-
-        if (surfaceTrackerLeaf.getRawType() == -1) { //light
-            this.lightHeightmaps[idx] = surfaceTrackerLeaf;
-        } else { // normal heightmap
-            this.heightmaps.computeIfAbsent(surfaceTrackerLeaf.getType(),
-                type -> new SurfaceTrackerLeaf[DIAMETER_IN_SECTIONS * DIAMETER_IN_SECTIONS]
-            )[idx] = surfaceTrackerLeaf;
         }
     }
 
@@ -373,7 +365,6 @@ public class ProtoCube extends ProtoChunk implements CubeAccess, CubicLevelHeigh
                     // On creation of a new node for a cube, both the node and its parents must be marked dirty
                     leaf.setAllDirty();
                     surfaceTrackerLeaves[idx] = leaf;
-                    sectionLoaded(leaf, dx, dz);
                 }
             }
             return surfaceTrackerLeaves;
@@ -539,6 +530,10 @@ public class ProtoCube extends ProtoChunk implements CubeAccess, CubicLevelHeigh
         int zSection = blockToCubeLocalSection(z);
 
         int idx = xSection + zSection * DIAMETER_IN_SECTIONS;
+
+        if (this.lightHeightmaps[idx] == null)
+            System.out.println("!");
+
         SurfaceTrackerLeaf sectionAbove = this.lightHeightmaps[idx].getSectionAbove();
 
         int dy = CubeAccess.DIAMETER_IN_BLOCKS - 1;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunk/ProtoCube.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunk/ProtoCube.java
@@ -224,7 +224,8 @@ public class ProtoCube extends ProtoChunk implements CubeAccess, CubicLevelHeigh
                     }
                 }
 
-                lightHeightmap.loadCube(((CubicServerLevel) this.levelHeightAccessor).getHeightmapStorage(), this);
+                SurfaceTrackerLeaf lightLeaf = lightHeightmap.loadCube(((CubicServerLevel) this.levelHeightAccessor).getHeightmapStorage(), this, null);
+                sectionLoaded(lightLeaf, dx, dz);
 
                 for (int z = 0; z < SECTION_DIAMETER; z++) {
                     for (int x = 0; x < SECTION_DIAMETER; x++) {
@@ -368,12 +369,11 @@ public class ProtoCube extends ProtoChunk implements CubeAccess, CubicLevelHeigh
             for (int dx = 0; dx < CubeAccess.DIAMETER_IN_SECTIONS; dx++) {
                 for (int dz = 0; dz < CubeAccess.DIAMETER_IN_SECTIONS; dz++) {
                     int idx = dx + dz * CubeAccess.DIAMETER_IN_SECTIONS;
-                    SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(cubePos.getY(), null, (byte) type.ordinal());
-                    leaf.loadCube(dx, dz, ((CubicServerLevel) ((ServerLevelAccessor) this.levelHeightAccessor).getLevel()).getHeightmapStorage(), this);
+                    SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(this, null, (byte) type.ordinal());
                     // On creation of a new node for a cube, both the node and its parents must be marked dirty
                     leaf.setAllDirty();
-                    leaf.markAncestorsDirty();
                     surfaceTrackerLeaves[idx] = leaf;
+                    sectionLoaded(leaf, dx, dz);
                 }
             }
             return surfaceTrackerLeaves;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/HeightmapNode.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/HeightmapNode.java
@@ -6,10 +6,6 @@ import io.github.opencubicchunks.cubicchunks.world.level.levelgen.heightmap.surf
 
 public interface HeightmapNode {
 
-    default void sectionLoaded(@Nonnull SurfaceTrackerLeaf surfaceTrackerLeaf, int localSectionX, int localSectionZ) {
-        throw new IllegalStateException("Should not be reached");
-    }
-
     void unloadNode(@Nonnull HeightmapStorage storage);
 
     int getHighest(int x, int z, byte heightmapType);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerBranch.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerBranch.java
@@ -43,7 +43,7 @@ public class SurfaceTrackerBranch extends SurfaceTrackerNode {
         }
     }
 
-    @Override public void loadCube(int localSectionX, int localSectionZ, HeightmapStorage storage, HeightmapNode newNode) {
+    public SurfaceTrackerLeaf loadCube(int localSectionX, int localSectionZ, HeightmapStorage storage, HeightmapNode newNode, @Nullable SurfaceTrackerLeaf protoLeaf) {
         int newScale = scale - 1;
 
         // Attempt to load all children from storage
@@ -56,17 +56,38 @@ public class SurfaceTrackerBranch extends SurfaceTrackerNode {
 
         int idx = indexOfRawHeightNode(newNode.getNodeY(), scale, scaledY);
         int newScaledY = indexToScaledY(idx, scale, scaledY);
-        if (children[idx] == null) {
-            // If the child containing new node has not been loaded from storage, create it
-            // Scale 1 nodes create leaf node children
-            if (newScale == 0) {
-                children[idx] = new SurfaceTrackerLeaf(newScaledY, this, this.heightmapType);
+
+        // child is a leaf
+        if (newScale == 0) {
+
+            assert children[idx] == null : "Duplicate leaf!";
+
+            SurfaceTrackerLeaf newLeaf;
+            if (protoLeaf == null) {
+                newLeaf = new SurfaceTrackerLeaf(newNode, this, this.heightmapType);
             } else {
+                newLeaf = new SurfaceTrackerLeaf(newNode, this, protoLeaf);
+            }
+            children[idx] = newLeaf;
+            newNode.sectionLoaded(newLeaf, localSectionX, localSectionZ);
+            newLeaf.markAncestorsDirty();
+
+            onChildLoaded();
+
+            return newLeaf;
+        }
+
+        // child is a branch
+        else {
+
+            if (children[idx] == null) {
                 children[idx] = new SurfaceTrackerBranch(newScale, newScaledY, this, this.heightmapType);
             }
+
+            return ((SurfaceTrackerBranch) children[idx]).loadCube(localSectionX, localSectionZ, storage, newNode, protoLeaf);
         }
-        children[idx].loadCube(localSectionX, localSectionZ, storage, newNode);
     }
+
 
     @Override protected void unload(HeightmapStorage storage) {
         for (SurfaceTrackerNode child : this.children) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerNode.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerNode.java
@@ -56,14 +56,6 @@ public abstract class SurfaceTrackerNode {
     }
 
 
-    private BitStorage getRawHeights() {
-        return heights;
-    }
-
-    private long[] getDirtyPositions()  {
-        return dirtyPositions;
-    }
-
     /**
      * Get the height for a given position. Recomputes the height if the column is marked dirty in this section.
      * x and z are <b>GLOBAL</b> coordinates (cube local is also fine, but section/chunk local is WRONG).

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerNode.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerNode.java
@@ -40,14 +40,28 @@ public abstract class SurfaceTrackerNode {
     protected final byte heightmapType;
 
     public SurfaceTrackerNode(int scale, int scaledY, @Nullable SurfaceTrackerBranch parent, byte heightmapType) {
-//      super((ChunkAccess) node, types);
-        // +1 in bit size to make room for null values
-        this.heights = new BitStorage(BASE_SIZE_BITS + 1 + scale * NODE_COUNT_BITS, WIDTH_BLOCKS * WIDTH_BLOCKS);
-        this.dirtyPositions = new long[WIDTH_BLOCKS * WIDTH_BLOCKS / Long.SIZE];
+        this(scale, scaledY, parent, heightmapType,
+            new BitStorage(BASE_SIZE_BITS + 1 + scale * NODE_COUNT_BITS, WIDTH_BLOCKS * WIDTH_BLOCKS),
+            new long[WIDTH_BLOCKS * WIDTH_BLOCKS / Long.SIZE]
+        );
+    }
+
+    protected SurfaceTrackerNode(int scale, int scaledY, @Nullable SurfaceTrackerBranch parent, byte heightmapType, BitStorage heights, long[] dirtyPositions) {
+        this.heights = heights;
+        this.dirtyPositions = dirtyPositions;
         this.parent = parent;
         this.scaledY = scaledY;
         this.scale = (byte) scale;
         this.heightmapType = heightmapType;
+    }
+
+
+    private BitStorage getRawHeights() {
+        return heights;
+    }
+
+    private long[] getDirtyPositions()  {
+        return dirtyPositions;
     }
 
     /**
@@ -67,8 +81,6 @@ public abstract class SurfaceTrackerNode {
      * Updates height for given position, and returns the new (global) height
      */
     protected abstract int updateHeight(int x, int z, int idx);
-
-    public abstract void loadCube(int localSectionX, int localSectionZ, HeightmapStorage storage, HeightmapNode newNode);
 
     /**
      * Tells a node to unload itself, nulling its parent, and passing itself to the provided storage

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerSectionStorage.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerSectionStorage.java
@@ -15,7 +15,7 @@ public class SurfaceTrackerSectionStorage implements HeightmapStorage {
         saved.put(new PackedTypeScaleScaledY(surfaceTrackerNode.heightmapType, surfaceTrackerNode.scale, surfaceTrackerNode.scaledY), surfaceTrackerNode);
 
         if (surfaceTrackerNode.scale == 0) {
-            ((SurfaceTrackerLeaf) surfaceTrackerNode).node = null;
+// TODO:            ((SurfaceTrackerLeaf) surfaceTrackerNode).node = null;
         } else {
             Arrays.fill(((SurfaceTrackerBranch) surfaceTrackerNode).children, null);
         }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerWrapper.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerWrapper.java
@@ -76,8 +76,8 @@ public class SurfaceTrackerWrapper extends Heightmap {
         return data.getRaw();
     }
 
-    public synchronized void loadCube(HeightmapStorage storage, HeightmapNode node) {
-        this.surfaceTracker.loadCube(blockToCubeLocalSection(dx), blockToCubeLocalSection(dz), storage, node);
+    public synchronized SurfaceTrackerLeaf loadCube(HeightmapStorage storage, HeightmapNode node, @Nullable SurfaceTrackerLeaf protoLeaf) {
+        return this.surfaceTracker.loadCube(blockToCubeLocalSection(dx), blockToCubeLocalSection(dz), storage, node, protoLeaf);
     }
 
     @Nullable

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerWrapper.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/levelgen/heightmap/surfacetrackertree/SurfaceTrackerWrapper.java
@@ -77,7 +77,7 @@ public class SurfaceTrackerWrapper extends Heightmap {
     }
 
     public synchronized SurfaceTrackerLeaf loadCube(HeightmapStorage storage, HeightmapNode node, @Nullable SurfaceTrackerLeaf protoLeaf) {
-        return this.surfaceTracker.loadCube(blockToCubeLocalSection(dx), blockToCubeLocalSection(dz), storage, node, protoLeaf);
+        return this.surfaceTracker.loadCube(storage, node, protoLeaf);
     }
 
     @Nullable

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerBranchTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerBranchTest.java
@@ -37,7 +37,7 @@ public class SurfaceTrackerBranchTest {
     public void testLeafInsertionIntoRoot() {
         NullHeightmapStorage storage = new NullHeightmapStorage();
         SurfaceTrackerBranch root = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
-        root.loadCube(0, 0, storage, new TestHeightmapNode(0), null);
+        root.loadCube(storage, new TestHeightmapNode(0), null);
 
         SurfaceTrackerLeaf leaf = root.getMinScaleNode(0);
         assertNotNull(leaf, "Appropriate leaf was null after loading node into root");

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerBranchTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerBranchTest.java
@@ -37,7 +37,7 @@ public class SurfaceTrackerBranchTest {
     public void testLeafInsertionIntoRoot() {
         NullHeightmapStorage storage = new NullHeightmapStorage();
         SurfaceTrackerBranch root = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
-        root.loadCube(0, 0, storage, new TestHeightmapNode(0));
+        root.loadCube(0, 0, storage, new TestHeightmapNode(0), null);
 
         SurfaceTrackerLeaf leaf = root.getMinScaleNode(0);
         assertNotNull(leaf, "Appropriate leaf was null after loading node into root");

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerLeafTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerLeafTest.java
@@ -49,7 +49,7 @@ public class SurfaceTrackerLeafTest {
 
         //Set up leaf and node with parent
         SurfaceTrackerBranch parent = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
-        parent.loadCube(0, 0, storage, new TestHeightmapNode(0), null);
+        parent.loadCube(storage, new TestHeightmapNode(0), null);
         SurfaceTrackerLeaf leaf = parent.getMinScaleNode(0);
 
         //Unload the node

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerLeafTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerLeafTest.java
@@ -30,9 +30,10 @@ public class SurfaceTrackerLeafTest {
      */
     @Test
     public void testCubeLoadUnload() {
-        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(0, null, (byte) 0);
 
-        leaf.loadCube(0, 0, null, new TestHeightmapNode(0));
+        TestHeightmapNode testNode = new TestHeightmapNode(0);
+        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(testNode, null, (byte) 0);
+
         assertNotNull(leaf.getNode(), "Leaf had null HeightmapNode after being loaded");
 
         leaf.cubeUnloaded(0, 0, null);
@@ -48,7 +49,7 @@ public class SurfaceTrackerLeafTest {
 
         //Set up leaf and node with parent
         SurfaceTrackerBranch parent = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
-        parent.loadCube(0, 0, storage, new TestHeightmapNode(0));
+        parent.loadCube(0, 0, storage, new TestHeightmapNode(0), null);
         SurfaceTrackerLeaf leaf = parent.getMinScaleNode(0);
 
         //Unload the node
@@ -63,11 +64,9 @@ public class SurfaceTrackerLeafTest {
      */
     @Test
     public void testNoValidHeights() {
-        NullHeightmapStorage storage = new NullHeightmapStorage();
 
-        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(0, null, (byte) 0);
         TestHeightmapNode testNode = new TestHeightmapNode(0);
-        leaf.loadCube(0, 0, storage, testNode);
+        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(testNode, null, (byte) 0);
 
         Consumer<HeightmapBlock> setHeight = block -> testNode.setBlock(block.x(), block.y() & (SurfaceTrackerLeaf.SCALE_0_NODE_HEIGHT - 1), block.z(), block.isOpaque());
 
@@ -92,11 +91,8 @@ public class SurfaceTrackerLeafTest {
     public void testBasicFunctionality() {
         ReferenceHeightmap reference = new ReferenceHeightmap(0);
 
-        NullHeightmapStorage storage = new NullHeightmapStorage();
-
-        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(0, null, (byte) 0);
         TestHeightmapNode testNode = new TestHeightmapNode(0);
-        leaf.loadCube(0, 0, storage, testNode);
+        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(testNode, null, (byte) 0);
 
         Consumer<HeightmapBlock> setHeight = block -> {
             reference.set(block.y(), block.isOpaque());
@@ -135,11 +131,8 @@ public class SurfaceTrackerLeafTest {
     public void testManyPositions(int nodeY) {
         ReferenceHeightmap reference = new ReferenceHeightmap(nodeY);
 
-        NullHeightmapStorage storage = new NullHeightmapStorage();
-
-        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(nodeY, null, (byte) 0);
         TestHeightmapNode testNode = new TestHeightmapNode(nodeY);
-        leaf.loadCube(0, 0, storage, testNode);
+        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(testNode, null, (byte) 0);
 
         Consumer<HeightmapBlock> setHeight = block -> {
             reference.set(block.y(), block.isOpaque());
@@ -177,11 +170,8 @@ public class SurfaceTrackerLeafTest {
     public void testSeededRandom() {
         ReferenceHeightmap reference = new ReferenceHeightmap(0);
 
-        NullHeightmapStorage storage = new NullHeightmapStorage();
-
-        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(0, null, (byte) 0);
         TestHeightmapNode testNode = new TestHeightmapNode(0);
-        leaf.loadCube(0, 0, storage, testNode);
+        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(testNode, null, (byte) 0);
 
         Consumer<HeightmapBlock> setHeight = block -> {
             reference.set(block.y(), block.isOpaque());
@@ -208,10 +198,9 @@ public class SurfaceTrackerLeafTest {
      */
     @Test
     public void testBounds() {
-        NullHeightmapStorage storage = new NullHeightmapStorage();
 
-        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(0, null, (byte) 0);
-        leaf.loadCube(0, 0, storage, new TestHeightmapNode(0));
+        TestHeightmapNode node = new TestHeightmapNode(0);
+        SurfaceTrackerLeaf leaf = new SurfaceTrackerLeaf(node, null, (byte) 0);
 
         Consumer<HeightmapBlock> setHeight = block -> {
             leaf.onSetBlock(block.x(), block.y(), block.z(), type -> block.isOpaque());

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerNodesTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerNodesTest.java
@@ -58,7 +58,7 @@ public class SurfaceTrackerNodesTest {
 
         for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
             for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node0, null);
+                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(storage, node0, null);
             }
         }
 
@@ -102,7 +102,7 @@ public class SurfaceTrackerNodesTest {
 
         for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
             for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node0, null);
+                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(storage, node0, null);
             }
         }
 
@@ -150,7 +150,7 @@ public class SurfaceTrackerNodesTest {
                 TestHeightmapNode node = new TestHeightmapNode(y);
                 for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                     for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                        roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node,null);
+                        roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(storage, node,null);
                     }
                 }
                 return node;
@@ -188,7 +188,7 @@ public class SurfaceTrackerNodesTest {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
             for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                 for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node, null);
+                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(storage, node, null);
                 }
             }
             return node;
@@ -226,7 +226,7 @@ public class SurfaceTrackerNodesTest {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
             for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                 for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node, null);
+                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(storage, node, null);
                 }
             }
             return node;
@@ -280,7 +280,7 @@ public class SurfaceTrackerNodesTest {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
             for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                 for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node, null);
+                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(storage, node, null);
                 }
             }
             return node;
@@ -329,7 +329,7 @@ public class SurfaceTrackerNodesTest {
 
         Function<Integer, TestHeightmapNode> loadNode = y -> nodes.computeIfAbsent(y, yPos -> {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
-            root.loadCube(0, 0, storage, node,null);
+            root.loadCube(storage, node,null);
             return node;
         });
         Function<Integer, TestHeightmapNode> unloadNode = y -> {
@@ -349,7 +349,7 @@ public class SurfaceTrackerNodesTest {
 
         unloadNode.apply(0);
 
-        root.loadCube(0, 0, storage, cubeNode, null);
+        root.loadCube(storage, cubeNode, null);
 
         SurfaceTrackerLeaf reloadedNode = root.getMinScaleNode(0);
 
@@ -486,10 +486,6 @@ public class SurfaceTrackerNodesTest {
                 fail(String.format("No section loaded for position (%d, %d, %d)", x, Coords.blockToCube(this.y) + localY, z));
             }
             section.onSetBlock(x, (this.y << SurfaceTrackerNode.SCALE_0_NODE_BITS) + localY, z, heightmapType -> isOpaque);
-        }
-
-        @Override public void sectionLoaded(@Nonnull SurfaceTrackerLeaf leaf, int localSectionX, int localSectionZ) {
-            this.sections[localSectionX + localSectionZ * CubeAccess.DIAMETER_IN_SECTIONS] = leaf;
         }
 
         @Override public void unloadNode(@Nonnull HeightmapStorage storage) {

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerNodesTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/levelgen/heightmap/SurfaceTrackerNodesTest.java
@@ -51,14 +51,14 @@ public class SurfaceTrackerNodesTest {
         ReferenceHeightmap reference = new ReferenceHeightmap(2048);
         
         TestHeightmapNode node0 = new TestHeightmapNode(0);
-        SurfaceTrackerNode[] roots = new SurfaceTrackerNode[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
+        SurfaceTrackerBranch[] roots = new SurfaceTrackerBranch[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
         for (int i = 0; i < roots.length; i++) {
             roots[i] = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
         }
 
         for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
             for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node0);
+                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node0, null);
             }
         }
 
@@ -95,14 +95,14 @@ public class SurfaceTrackerNodesTest {
         ReferenceHeightmap reference = new ReferenceHeightmap(2048);
 
         TestHeightmapNode node0 = new TestHeightmapNode(0);
-        SurfaceTrackerNode[] roots = new SurfaceTrackerNode[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
+        SurfaceTrackerBranch[] roots = new SurfaceTrackerBranch[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
         for (int i = 0; i < roots.length; i++) {
-            roots[i] = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
+            roots[i] = new SurfaceTrackerBranch(SurfaceTrackerBranch.MAX_SCALE, 0, null, (byte) 0);
         }
 
         for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
             for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node0);
+                roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node0, null);
             }
         }
 
@@ -139,7 +139,7 @@ public class SurfaceTrackerNodesTest {
         ReferenceHeightmap reference = new ReferenceHeightmap(maxCoordinate);
 
         Map<Integer, TestHeightmapNode> nodes = new HashMap<>();
-        SurfaceTrackerNode[] roots = new SurfaceTrackerNode[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
+        SurfaceTrackerBranch[] roots = new SurfaceTrackerBranch[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
         for (int i = 0; i < roots.length; i++) {
             roots[i] = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
         }
@@ -150,7 +150,7 @@ public class SurfaceTrackerNodesTest {
                 TestHeightmapNode node = new TestHeightmapNode(y);
                 for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                     for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                        roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node);
+                        roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node,null);
                     }
                 }
                 return node;
@@ -179,7 +179,7 @@ public class SurfaceTrackerNodesTest {
         TestHeightmapStorage storage = new TestHeightmapStorage();
 
         Map<Integer, TestHeightmapNode> nodes = new HashMap<>();
-        SurfaceTrackerNode[] roots = new SurfaceTrackerNode[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
+        SurfaceTrackerBranch[] roots = new SurfaceTrackerBranch[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
         for (int i = 0; i < roots.length; i++) {
             roots[i] = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
         }
@@ -188,7 +188,7 @@ public class SurfaceTrackerNodesTest {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
             for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                 for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node);
+                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node, null);
                 }
             }
             return node;
@@ -217,7 +217,7 @@ public class SurfaceTrackerNodesTest {
         TestHeightmapStorage storage = new TestHeightmapStorage();
 
         Map<Integer, TestHeightmapNode> nodes = new HashMap<>();
-        SurfaceTrackerNode[] roots = new SurfaceTrackerNode[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
+        SurfaceTrackerBranch[] roots = new SurfaceTrackerBranch[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
         for (int i = 0; i < roots.length; i++) {
             roots[i] = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
         }
@@ -226,7 +226,7 @@ public class SurfaceTrackerNodesTest {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
             for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                 for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node);
+                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node, null);
                 }
             }
             return node;
@@ -271,7 +271,7 @@ public class SurfaceTrackerNodesTest {
         TestHeightmapStorage storage = new TestHeightmapStorage();
 
         Map<Integer, TestHeightmapNode> nodes = new HashMap<>();
-        SurfaceTrackerNode[] roots = new SurfaceTrackerNode[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
+        SurfaceTrackerBranch[] roots = new SurfaceTrackerBranch[CubeAccess.DIAMETER_IN_SECTIONS * CubeAccess.DIAMETER_IN_SECTIONS];
         for (int i = 0; i < roots.length; i++) {
             roots[i] = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
         }
@@ -280,7 +280,7 @@ public class SurfaceTrackerNodesTest {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
             for (int localSectionX = 0; localSectionX < CubeAccess.DIAMETER_IN_SECTIONS; localSectionX++) {
                 for (int localSectionZ = 0; localSectionZ < CubeAccess.DIAMETER_IN_SECTIONS; localSectionZ++) {
-                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node);
+                    roots[localSectionX + CubeAccess.DIAMETER_IN_SECTIONS * localSectionZ].loadCube(localSectionX, localSectionZ, storage, node, null);
                 }
             }
             return node;
@@ -325,11 +325,11 @@ public class SurfaceTrackerNodesTest {
         TestHeightmapStorage storage = new TestHeightmapStorage();
 
         Map<Integer, TestHeightmapNode> nodes = new HashMap<>();
-        SurfaceTrackerNode root = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
+        SurfaceTrackerBranch root = new SurfaceTrackerBranch(SurfaceTrackerNode.MAX_SCALE, 0, null, (byte) 0);
 
         Function<Integer, TestHeightmapNode> loadNode = y -> nodes.computeIfAbsent(y, yPos -> {
             TestHeightmapNode node = new TestHeightmapNode(yPos);
-            root.loadCube(0, 0, storage, node);
+            root.loadCube(0, 0, storage, node,null);
             return node;
         });
         Function<Integer, TestHeightmapNode> unloadNode = y -> {
@@ -349,7 +349,7 @@ public class SurfaceTrackerNodesTest {
 
         unloadNode.apply(0);
 
-        root.loadCube(0, 0, storage, cubeNode);
+        root.loadCube(0, 0, storage, cubeNode, null);
 
         SurfaceTrackerLeaf reloadedNode = root.getMinScaleNode(0);
 
@@ -421,12 +421,13 @@ public class SurfaceTrackerNodesTest {
      */
     static class NullHeightmapStorage implements HeightmapStorage {
         @Override public void unloadNode(SurfaceTrackerNode node) {
-            if (node.getScale() == 0) {
-                ((SurfaceTrackerLeaf) node).setNode(null);
-            } else {
-                Arrays.fill(((SurfaceTrackerBranch) node).getChildren(), null);
-            }
-            node.setParent(null);
+            throw new RuntimeException("Not implemented");
+//            if (node.getScale() == 0) {
+//                ((SurfaceTrackerLeaf) node).setNode(null);
+//            } else {
+//                Arrays.fill(((SurfaceTrackerBranch) node).getChildren(), null);
+//            }
+//            node.setParent(null);
         }
 
         @Nullable @Override public SurfaceTrackerNode loadNode(SurfaceTrackerBranch parent, byte heightmapType, int scale, int scaledY) {
@@ -441,14 +442,15 @@ public class SurfaceTrackerNodesTest {
         Object2ReferenceMap<PackedTypeScaleScaledY, SurfaceTrackerNode> saved = new Object2ReferenceOpenHashMap<>();
 
         @Override public void unloadNode(SurfaceTrackerNode node) {
-            if (node.getScale() == 0) {
-                ((SurfaceTrackerLeaf) node).setNode(null);
-            } else {
-                Arrays.fill(((SurfaceTrackerBranch) node).getChildren(), null);
-            }
-            node.setParent(null);
-
-            saved.put(new PackedTypeScaleScaledY(node.getRawType(), node.getScale(), node.getScaledY()), node);
+            throw new RuntimeException("Not implemented");
+//            if (node.getScale() == 0) {
+//                ((SurfaceTrackerLeaf) node).setNode(null);
+//            } else {
+//                Arrays.fill(((SurfaceTrackerBranch) node).getChildren(), null);
+//            }
+//            node.setParent(null);
+//
+//            saved.put(new PackedTypeScaleScaledY(node.getRawType(), node.getScale(), node.getScaledY()), node);
         }
         @Override public SurfaceTrackerNode loadNode(SurfaceTrackerBranch parent, byte heightmapType, int scale, int scaledY) {
             SurfaceTrackerNode removed = saved.remove(new PackedTypeScaleScaledY(heightmapType, scale, scaledY));


### PR DESCRIPTION
This PR is supposed to tackle the following issues:

1. Complex coupling between HeightmapNode, SurfaceTrackerLeaf and SurfaceTrackerBranch
HeightmapNodes (LevelCube and ProtoCube) contain references to SurfaceTrackerLeaves and vice-versa. The HightmapNodes create SurfaceTrackerLeaves, which then invoke a method "sectionLoaded" that adds the SurfaceTrackerLeaf to a reference list within the HeightmapNode. Instead HeightmapNodes should simply create the leaves and add them to their internal lists themselves.

2. Faulty handling of heightmaps during ProtoCube promotion to LevelCube
When a LevelCube is created based on a ProtoCube, it should inherit all of the ProtoCube's heightmaps. As of right now, this behaviour is faulty because of the overly complex interactions between cubes and heightmaps.