### PR TITLE
Fix strange weather rendering at high altitudes

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/render/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/render/MixinLevelRenderer.java
@@ -1,0 +1,113 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.client.render;
+
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.Tesselator;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(LevelRenderer.class)
+public class MixinLevelRenderer {
+    //Fixes the broken weather at high heights
+
+    private static final int ROLLOVER = 64 * 4; //Will look stupid if it isn't a multiple of 4
+    private int betterUForUV, betterVForUV;
+
+    @SuppressWarnings("InvalidInjectorMethodSignature")
+    @Inject(
+        method = "renderSnowAndRain",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/core/BlockPos$MutableBlockPos;set(III)Lnet/minecraft/core/BlockPos$MutableBlockPos;",
+            shift = At.Shift.AFTER,
+            ordinal = 1
+        ),
+        locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void prepareBetterUV(LightTexture lightTexture, float f, double d, double e, double g, CallbackInfo ci, float h, Level level, int i, int j, int k,
+                                 Tesselator tesselator, BufferBuilder bufferBuilder, int l, int m, float n, BlockPos.MutableBlockPos mutableBlockPos, int o, int p, int q,
+                                 double r, double s, Biome biome, int t, int u, int v, int w) {
+        this.betterUForUV = u % ROLLOVER;
+        this.betterVForUV = v % ROLLOVER;
+
+        if (this.betterUForUV > this.betterVForUV) {
+            this.betterVForUV += ROLLOVER;
+        }
+    }
+
+    //This is the best way I could figure out how ot do with mixins.
+    //Before VertexConsumer.uv() is called, it will swap u and v with betterUForUV and betterVForUV
+    //This means uv() gets the rolled-over values to improve precision
+    //After the call, it will swap them back so that the original values are used in any other places
+    @ModifyVariable(
+        method = "renderSnowAndRain",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/blaze3d/vertex/BufferBuilder;vertex(DDD)Lcom/mojang/blaze3d/vertex/VertexConsumer;",
+            shift = At.Shift.AFTER
+        ),
+        name = "u"
+    )
+    private int swapUPre(int u) {
+        int temp = this.betterUForUV;
+        this.betterUForUV = u;
+
+        return temp;
+    }
+
+    @ModifyVariable(
+        method = "renderSnowAndRain",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/blaze3d/vertex/BufferBuilder;vertex(DDD)Lcom/mojang/blaze3d/vertex/VertexConsumer;",
+            shift = At.Shift.AFTER
+        ),
+        name = "v"
+    )
+    private int swapVPre(int v) {
+        int temp = this.betterVForUV;
+        this.betterVForUV = v;
+
+        return temp;
+    }
+
+    @ModifyVariable(
+        method = "renderSnowAndRain",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/blaze3d/vertex/VertexConsumer;uv(FF)Lcom/mojang/blaze3d/vertex/VertexConsumer;",
+            shift = At.Shift.AFTER
+        ),
+        name = "u"
+    )
+    private int swapUPost(int u) {
+        int temp = this.betterUForUV;
+        this.betterUForUV = u;
+
+        return temp;
+    }
+
+    @ModifyVariable(
+        method = "renderSnowAndRain",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/blaze3d/vertex/VertexConsumer;uv(FF)Lcom/mojang/blaze3d/vertex/VertexConsumer;",
+            shift = At.Shift.AFTER
+        ),
+        name = "v"
+    )
+    private int swapVPost(int v) {
+        int temp = this.betterVForUV;
+        this.betterVForUV = v;
+
+        return temp;
+    }
+}

--- a/src/main/resources/cubicchunks.mixins.core.json
+++ b/src/main/resources/cubicchunks.mixins.core.json
@@ -56,8 +56,7 @@
         "common.progress.MixinLoggerChunkProgressListener",
         "common.server.MixinPlayerList",
         "common.ticket.MixinChunkMapDistanceManager",
-        "common.ticket.MixinDistanceManager",
-        "client.render.MixinLevelRenderer"
+        "common.ticket.MixinDistanceManager"
     ],
     "client": [
         "client.chunk.MixinLevelChunk",
@@ -75,6 +74,7 @@
         "client.progress.MixinProcessorChunkProgressListener",
         "client.progress.MixinStoringChunkProgressListener",
         "client.render.MixinGameRenderer",
+        "client.render.MixinLevelRenderer",
         "client.render.MixinRenderChunk",
         "client.render.MixinRenderChunkRegion",
         "client.render.MixinViewArea",

--- a/src/main/resources/cubicchunks.mixins.core.json
+++ b/src/main/resources/cubicchunks.mixins.core.json
@@ -56,7 +56,8 @@
         "common.progress.MixinLoggerChunkProgressListener",
         "common.server.MixinPlayerList",
         "common.ticket.MixinChunkMapDistanceManager",
-        "common.ticket.MixinDistanceManager"
+        "common.ticket.MixinDistanceManager",
+        "client.render.MixinLevelRenderer"
     ],
     "client": [
         "client.chunk.MixinLevelChunk",


### PR DESCRIPTION
Above a few 10000 blocks, the rendering of rain and snow starts degenerating. (Although in normal circumstances, only snow would happen at those heights). The textures become jittery and the snow would suddenly "jump" up and down. At very high altitudes it becomes horreneous. Below are images at y = 50000 and y = 1000000.
![2022-04-08_18 30 09](https://user-images.githubusercontent.com/57073913/162379711-fd4a3797-cb52-4099-8065-b0ba1ebe3e3c.png)
![2022-04-08_18 30 24](https://user-images.githubusercontent.com/57073913/162379777-6fd9d8c4-1146-48eb-859e-96d83c4fe1f1.png)

This is due to the fact that the y-coordinate of the player contributes to the uv (specifically v coordinates). At some point they are turned to a float and precision is lost, causing the jumps. OpenGL also seems to have a hard time with the very large UV coordinates and the texture wrapping degenerates.

This PR fixes those issues by wrapping those values to a small range (-256 to 256) before they are turned to floats and used as UVs. Below is snow at y=1000000 after theses changes.
![2022-04-08_18 31 24](https://user-images.githubusercontent.com/57073913/162380362-5045fe4f-0452-4af6-a7cc-1f95e9030181.png)

