### PR TITLE
Add declarative ASM parser and port majority of ASM to it

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
@@ -87,19 +87,14 @@ public class ASMConfigPlugin implements IMixinConfigPlugin {
 
     @Override public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
         MappingResolver map = FabricLoader.getInstance().getMappingResolver();
-        String chunkMapDistanceManager = map.mapClassName("intermediary", "net.minecraft.class_3898$class_3216");
 
         //TODO: untangle the mess of some methods accepting the/class/name, and others accepting the.class.name
         //Ideally the input json would all have the same, and we'd just figure it out here
-        if (targetClassName.equals(chunkMapDistanceManager)) {
-            MainTransformer.transformProxyTicketManager(targetClass);
+        RedirectsParser.ClassTarget target = classTargetByName.get(map.unmapClassName("intermediary", targetClassName).replace(".", "/"));
+        if (target != null) {
+            MainTransformer.transformClass(targetClass, target, redirectSetsByClassTarget.get(target));
         } else {
-            RedirectsParser.ClassTarget target = classTargetByName.get(map.unmapClassName("intermediary", targetClassName).replace(".", "/"));
-            if (target != null) {
-                MainTransformer.transformClass(targetClass, target, redirectSetsByClassTarget.get(target));
-            } else {
-                System.err.printf("Couldn't find target class %s to remap", targetClassName);
-            }
+            System.err.printf("Couldn't find target class %s to remap", targetClassName);
         }
 
         try {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
@@ -94,7 +94,7 @@ public class ASMConfigPlugin implements IMixinConfigPlugin {
         if (target != null) {
             MainTransformer.transformClass(targetClass, target, redirectSetsByClassTarget.get(target));
         } else {
-            System.err.printf("Couldn't find target class %s to remap", targetClassName);
+            throw new RuntimeException(new ClassNotFoundException(String.format("Couldn't find target class %s to remap", targetClassName)));
         }
 
         try {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/MainTransformer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/MainTransformer.java
@@ -86,29 +86,6 @@ public class MainTransformer {
         });
     }
 
-    public static void transformProxyTicketManager(ClassNode targetClass) {
-        final ClassMethod setChunkLevel = new ClassMethod(getObjectType("net/minecraft/class_3204"),
-            getMethod("net.minecraft.class_3193 " // ChunkHolder
-                + "method_14053(long, int, " // updateChunkScheduling
-                + "net.minecraft.class_3193, int)")); // ChunkHolder
-        final String updateCubeScheduling = "updateCubeScheduling";
-
-        Map<ClassMethod, String> methodRedirects = new HashMap<>();
-        methodRedirects.put(// synthetic accessor for method_14053 (updateChunkScheduling)
-            new ClassMethod(
-                getObjectType("net/minecraft/class_3898"), // ChunkMap
-                getMethod("net.minecraft.class_3193 " // ChunkHolder
-                    + "method_17217(" // access$400
-                    + "long, int, "
-                    + "net.minecraft.class_3193, int)") // ChunkHolder
-            ), updateCubeScheduling);
-
-        Map<ClassField, String> fieldRedirects = new HashMap<>();
-        Map<Type, Type> typeRedirects = new HashMap<>();
-
-        cloneAndApplyRedirects(targetClass, setChunkLevel, updateCubeScheduling, methodRedirects, fieldRedirects, typeRedirects);
-    }
-
     private static void makeStaticSyntheticAccessor(ClassNode node, MethodNode newMethod) {
         Type[] params = Type.getArgumentTypes(newMethod.desc);
         Type[] newParams = new Type[params.length + 1];

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/MainTransformer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/MainTransformer.java
@@ -52,7 +52,7 @@ public class MainTransformer {
             for (RedirectsParser.RedirectSet.FieldRedirect fieldRedirect : redirectSet.getFieldRedirects()) {
                 //annoying syntax only on field
                 String desc = fieldRedirect.fieldDesc();
-                if(desc.length() > 1) { //not a primitive type
+                if (desc.length() > 1) { //not a primitive type
                     desc = "L" + desc;
                 }
                 desc = desc + ";";
@@ -60,7 +60,7 @@ public class MainTransformer {
             }
 
             for (RedirectsParser.RedirectSet.MethodRedirect methodRedirect : redirectSet.getMethodRedirects()) {
-                if(methodRedirect.mappingsOwner() == null) {
+                if (methodRedirect.mappingsOwner() == null) {
                     methodRedirects.put(
                         new ClassMethod(getObjectType(methodRedirect.owner()), getMethod(methodRedirect.returnType() + " " + methodRedirect.srcMethodName())),
                         methodRedirect.dstMethodName()
@@ -80,7 +80,7 @@ public class MainTransformer {
                 methodRedirects,
                 fieldRedirects,
                 typeRedirects);
-            if(targetMethod.makeSyntheticAccessor()) {
+            if (targetMethod.makeSyntheticAccessor()) {
                 makeStaticSyntheticAccessor(targetClass, newMethod);
             }
         });

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/dasm/RedirectsParseException.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/dasm/RedirectsParseException.java
@@ -1,0 +1,16 @@
+package io.github.opencubicchunks.cubicchunks.mixin.transform.dasm;
+
+import java.io.IOException;
+
+public class RedirectsParseException extends IOException {
+    public RedirectsParseException(String message) {
+        super(message);
+    }
+    public RedirectsParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public RedirectsParseException(Throwable cause) {
+        super(cause);
+    }
+}
+

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/dasm/RedirectsParser.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/dasm/RedirectsParser.java
@@ -1,0 +1,350 @@
+package io.github.opencubicchunks.cubicchunks.mixin.transform.dasm;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+public class RedirectsParser {
+    private static final String TARGET_METHODS_NAME = "targetMethods";
+    private static final String USE_SETS_NAME = "useSets";
+    private static final String TYPE_REDIRECTS_NAME = "typeRedirects";
+    private static final String METHOD_REDIRECTS_NAME = "methodRedirects";
+    private static final String FIELD_REDIRECTS_NAME = "fieldRedirects";
+
+    private static final String MAKE_SYNTHETIC_ACCESSOR_NAME = "makeSyntheticAccessor";
+    private static final String MAPPINGS_OWNER_NAME = "mappingsOwner";
+    private static final String DST_NAME = "newName";
+
+    public List<RedirectSet> parseRedirectSet(JsonObject json) throws RedirectsParseException {
+        List<RedirectSet> redirectSets = new ArrayList<>();
+        for (Map.Entry<String, JsonElement> classRedirectObject : json.entrySet()) {
+            String redirectSetName = throwOnLengthZero(classRedirectObject.getKey(), () -> "Redirect Set node has empty name");
+
+            JsonElement redirectElement = classRedirectObject.getValue();
+            if (!redirectElement.isJsonObject()) {
+                throw new RedirectsParseException(String.format("Invalid redirect set node %s", redirectElement));
+            }
+            JsonObject redirectJson = redirectElement.getAsJsonObject();
+
+            RedirectSet redirectSet = new RedirectSet(redirectSetName);
+
+            if(!redirectJson.has(TYPE_REDIRECTS_NAME) || !redirectJson.get(TYPE_REDIRECTS_NAME).isJsonObject()) {
+                throw new RedirectsParseException(String.format("Redirect set has no \"%s\" object", TYPE_REDIRECTS_NAME));
+            }
+            Set<Map.Entry<String, JsonElement>> typeRedirects = redirectJson.get(TYPE_REDIRECTS_NAME).getAsJsonObject().entrySet();
+            parseTypeRedirects(redirectSet, typeRedirects);
+
+            if(!redirectJson.has(FIELD_REDIRECTS_NAME) || !redirectJson.get(FIELD_REDIRECTS_NAME).isJsonObject()) {
+                throw new RedirectsParseException(String.format("Redirect set has no \"%s\" object", FIELD_REDIRECTS_NAME));
+            }
+            Set<Map.Entry<String, JsonElement>> fieldRedirects = redirectJson.get(FIELD_REDIRECTS_NAME).getAsJsonObject().entrySet();
+            parseFieldRedirects(redirectSet, fieldRedirects);
+
+            if(!redirectJson.has(METHOD_REDIRECTS_NAME) || !redirectJson.get(METHOD_REDIRECTS_NAME).isJsonObject()) {
+                throw new RedirectsParseException(String.format("Redirect set has no \"%s\" object", METHOD_REDIRECTS_NAME));
+            }
+            Set<Map.Entry<String, JsonElement>> methodRedirects = redirectJson.get(METHOD_REDIRECTS_NAME).getAsJsonObject().entrySet();
+            parseMethodRedirects(redirectSet, methodRedirects);
+
+            redirectSets.add(redirectSet);
+        }
+
+        return redirectSets;
+    }
+
+    public List<ClassTarget> parseClassTargets(JsonObject json) throws RedirectsParseException {
+        List<ClassTarget> classTargets = new ArrayList<>();
+        for (Map.Entry<String, JsonElement> classRedirectObject : json.entrySet()) {
+            String classTargetName = throwOnLengthZero(classRedirectObject.getKey(), () -> "Class target node has empty name");
+
+            JsonElement classTargetElement = classRedirectObject.getValue();
+            if (!classTargetElement.isJsonObject()) {
+                throw new RedirectsParseException(String.format("Invalid Class target node %s", classTargetElement));
+            }
+            JsonObject classTargetNode = classTargetElement.getAsJsonObject();
+
+            if(!classTargetNode.has(USE_SETS_NAME)) {
+                throw new RedirectsParseException(String.format("Class target has no \"%s\" object", USE_SETS_NAME));
+            }
+
+            ClassTarget classTarget = new ClassTarget(classTargetName);
+
+            JsonElement usesSetNameElement = classTargetNode.get(USE_SETS_NAME);
+            if(usesSetNameElement.isJsonPrimitive() && usesSetNameElement.getAsJsonPrimitive().isString()) {
+                //single set
+                classTarget.addUsesSet(throwOnLengthZero(usesSetNameElement.getAsString(), () -> "Specified Class set name has zero length"));
+            } else if (usesSetNameElement.isJsonArray()) {
+                //multiple sets
+                JsonArray usesSetNames = usesSetNameElement.getAsJsonArray();
+                for (JsonElement usesSetName : usesSetNames) {
+                    classTarget.addUsesSet(usesSetName.getAsString());
+                }
+            }
+
+            // it's possible the class target just wants to redirect fields and so has no target methods
+            if (classTargetNode.has(TARGET_METHODS_NAME) && classTargetNode.get(TARGET_METHODS_NAME).isJsonObject()) {
+                Set<Map.Entry<String, JsonElement>> targetMethodsNode = classTargetNode.get(TARGET_METHODS_NAME).getAsJsonObject().entrySet();
+                parseTargetMethods(classTarget, targetMethodsNode);
+            }
+
+            classTargets.add(classTarget);
+        }
+
+        return classTargets;
+    }
+
+    private void parseTargetMethods(ClassTarget output, Set<Map.Entry<String, JsonElement>> methodRedirects) throws RedirectsParseException {
+        for (Map.Entry<String, JsonElement> methodRedirect : methodRedirects) {
+            ImmutableTriple<String, String, String> ownerIdentType = parseSignature(methodRedirect.getKey());
+            String ownerName = ownerIdentType.left;
+            String srcMethodName = ownerIdentType.middle;
+            String returnType = ownerIdentType.right;
+
+            JsonElement value = methodRedirect.getValue();
+            if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                String dstMethodName = throwOnLengthZero(value.getAsString(), () -> String.format("Target method has zero length value for key %s", methodRedirect));
+                output.addTarget(new ClassTarget.TargetMethod(ownerName, returnType, null, srcMethodName, dstMethodName, false));
+            } else if (value.isJsonObject()) { // target method might want a synthetic accessor
+                JsonObject targetMethodValue = value.getAsJsonObject();
+
+                if(!targetMethodValue.has(DST_NAME)) {
+                    throw new RedirectsParseException(String.format("Target method value does not contain a value for \"%s\". %s", DST_NAME, targetMethodValue));
+                }
+                JsonElement newNameNode = targetMethodValue.get(DST_NAME);
+                if(!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
+                    throw new RedirectsParseException(String.format("Target method value does not contain a valid \"%s\". %s", DST_NAME, newNameNode));
+                }
+
+                String dstMethodName = throwOnLengthZero(newNameNode.getAsString(), () -> String.format("Target method has zero length value for key %s", methodRedirect));
+
+                boolean makeSyntheticAccessor = getMakeSyntheticAccessorIfPresent(targetMethodValue);
+                String mappingsOwner = getMappingsOwnerIfPresent(targetMethodValue);
+
+                output.addTarget(new ClassTarget.TargetMethod(ownerName, returnType, mappingsOwner, srcMethodName, dstMethodName, makeSyntheticAccessor));
+            } else {
+                throw new RedirectsParseException(String.format("Could not parse Target method %s", methodRedirect));
+            }
+        }
+    }
+
+    private void parseTypeRedirects(RedirectSet output, Set<Map.Entry<String, JsonElement>> typeRedirects) throws RedirectsParseException {
+        for (Map.Entry<String, JsonElement> typeRedirect : typeRedirects) {
+            JsonElement value = typeRedirect.getValue();
+            if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+                throw new RedirectsParseException(String.format("Type redirect value has invalid structure: %s", value));
+            }
+            output.addRedirect(new RedirectSet.TypeRedirect(
+                throwOnLengthZero(typeRedirect.getKey(), () -> String.format("Type redirect has zero length string key: %s", typeRedirect)),
+                throwOnLengthZero(value.getAsString(), () -> String.format("Type redirect has zero length string value: %s", typeRedirect))
+            ));
+        }
+    }
+
+    private void parseFieldRedirects(RedirectSet output, Set<Map.Entry<String, JsonElement>> fieldRedirects) throws RedirectsParseException {
+        for (Map.Entry<String, JsonElement> fieldRedirect : fieldRedirects) {
+            ImmutableTriple<String, String, String> ownerIdentType = parseSignature(fieldRedirect.getKey());
+            String ownerName = ownerIdentType.left;
+            String srcFieldName = ownerIdentType.middle;
+            String fieldType = ownerIdentType.right;
+
+            JsonElement value = fieldRedirect.getValue();
+            if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                output.addRedirect(new RedirectSet.FieldRedirect(
+                    ownerName,
+                    fieldType,
+                    null,
+                    srcFieldName,
+                    throwOnLengthZero(value.getAsString(), () -> String.format("Field redirect has zero length string value: %s", fieldRedirect))
+                ));
+            } else if(value.isJsonObject()) { // field redirect might contain a mappings owner
+                JsonObject fieldRedirectValue = value.getAsJsonObject();
+
+                if(!fieldRedirectValue.has(DST_NAME)) {
+                    throw new RedirectsParseException(String.format("Field redirect value does not contain a value for \"%s\". %s", DST_NAME, fieldRedirectValue));
+                }
+                JsonElement newNameNode = fieldRedirectValue.get(DST_NAME);
+                if(!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
+                    throw new RedirectsParseException(String.format("Field redirect value does not contain a valid \"%s\". %s", DST_NAME, newNameNode));
+                }
+
+                String dstFieldName = throwOnLengthZero(newNameNode.getAsString(), () -> String.format("Field redirect has zero length value for key %s", fieldRedirect));
+                String mappingsOwner = getMappingsOwnerIfPresent(fieldRedirectValue);
+
+                output.addRedirect(new RedirectSet.FieldRedirect(ownerName, fieldType, mappingsOwner, srcFieldName, dstFieldName));
+            } else {
+                throw new RedirectsParseException(String.format("Field redirect value has invalid structure: %s", value));
+            }
+        }
+    }
+
+    private void parseMethodRedirects(RedirectSet output, Set<Map.Entry<String, JsonElement>> methodRedirects) throws RedirectsParseException {
+        for (Map.Entry<String, JsonElement> methodRedirect : methodRedirects) {
+            ImmutableTriple<String, String, String> ownerIdentType = parseSignature(methodRedirect.getKey());
+            String ownerName = ownerIdentType.left;
+            String srcMethodName = ownerIdentType.middle;
+            String returnType = ownerIdentType.right;
+
+            JsonElement value = methodRedirect.getValue();
+            if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
+                String dstMethodName = throwOnLengthZero(value.getAsString(), () -> String.format("Method redirect has zero length value for key %s", methodRedirect));
+                output.addRedirect(new RedirectSet.MethodRedirect(ownerName, returnType, null, srcMethodName, dstMethodName));
+            } else if(value.isJsonObject()) { // method redirect might contain a mappings owner
+                JsonObject methodRedirectValue = value.getAsJsonObject();
+
+                if(!methodRedirectValue.has(DST_NAME)) {
+                    throw new RedirectsParseException(String.format("Method redirect value does not contain a value for \"%s\". %s", DST_NAME, methodRedirectValue));
+                }
+                JsonElement newNameNode = methodRedirectValue.get(DST_NAME);
+                if(!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
+                    throw new RedirectsParseException(String.format("Method redirect value does not contain a valid \"%s\". %s", DST_NAME, newNameNode));
+                }
+
+                String dstMethodName = throwOnLengthZero(newNameNode.getAsString(), () -> String.format("Method redirect has zero length value for key %s", methodRedirect));
+                String mappingsOwner = getMappingsOwnerIfPresent(methodRedirectValue);
+
+                output.addRedirect(new RedirectSet.MethodRedirect(ownerName, returnType, mappingsOwner, srcMethodName, dstMethodName));
+            } else {
+                throw new RedirectsParseException(String.format("Could not parse Method redirect %s", methodRedirect));
+            }
+        }
+    }
+
+    private boolean getMakeSyntheticAccessorIfPresent(JsonObject redirectElement) throws RedirectsParseException {
+        boolean makeSyntheticAccessor = false;
+        if(redirectElement.has(MAKE_SYNTHETIC_ACCESSOR_NAME)) { // synthetic accessor is optional
+            JsonElement syntheticAccessorNode = redirectElement.get(MAKE_SYNTHETIC_ACCESSOR_NAME);
+            if(!syntheticAccessorNode.isJsonPrimitive() || !syntheticAccessorNode.getAsJsonPrimitive().isBoolean()) {
+                throw new RedirectsParseException(String.format("Redirect value does not contain a valid \"%s\". %s", MAKE_SYNTHETIC_ACCESSOR_NAME, syntheticAccessorNode));
+            }
+            makeSyntheticAccessor = syntheticAccessorNode.getAsBoolean();
+        }
+        return makeSyntheticAccessor;
+    }
+
+    private String getMappingsOwnerIfPresent(JsonObject targetMethodValue)
+        throws RedirectsParseException {
+        String mappingsOwner = null;
+        if(targetMethodValue.has(MAPPINGS_OWNER_NAME)) { // mappings owner is optional
+            JsonElement mappingsOwnerNode = targetMethodValue.get(MAPPINGS_OWNER_NAME);
+            if(!mappingsOwnerNode.isJsonPrimitive() || !mappingsOwnerNode.getAsJsonPrimitive().isString()) {
+                throw new RedirectsParseException(String.format("Redirect value does not contain a valid \"%s\". %s", MAPPINGS_OWNER_NAME, mappingsOwnerNode));
+            }
+            mappingsOwner = throwOnLengthZero(mappingsOwnerNode.getAsString(), () -> String.format("Field redirect has zero length value for %s: %s", MAPPINGS_OWNER_NAME, mappingsOwnerNode));
+        }
+        return mappingsOwner;
+    }
+
+    /**
+     * Accepts signature like owner#ident;type
+     * <p>eg: {@code net.minecraft.world.level.chunk.LevelChunk#sections;net.minecraft.world.level.chunk.LevelChunkSection}</p>
+     */
+    public static ImmutableTriple<String, String, String> parseSignature(String in) throws RedirectsParseException {
+        String s = throwOnLengthZero(in, () -> "Signature has zero length");
+
+        int ownerToIdentSeparator = s.lastIndexOf("#");
+        int identToTypeSeparator = s.lastIndexOf(";");
+
+        if (ownerToIdentSeparator == -1 || identToTypeSeparator == -1 || ownerToIdentSeparator >= identToTypeSeparator) {
+            // key contained no # symbol or no ; symbol, or they were in the wrong order
+            throw new RedirectsParseException(String.format("Invalid \"owner#ident;type\" signature: %s", s));
+        }
+
+        String owner = throwOnLengthZero(s.substring(0, ownerToIdentSeparator),
+            () -> String.format("Invalid \"owner#ident;type\" signature: %s", s));
+        String ident = throwOnLengthZero(s.substring(ownerToIdentSeparator + 1, identToTypeSeparator),
+            () -> String.format("Invalid \"owner#ident;type\" signature: %s", s));
+        String type = throwOnLengthZero(s.substring(identToTypeSeparator + 1, s.length()),
+            () -> String.format("Invalid \"owner#ident;type\" signature: %s", s));
+
+        return new ImmutableTriple<>(owner, ident, type);
+    }
+
+    private static String throwOnLengthZero(String string, Supplier<String> message) throws RedirectsParseException {
+        if (string.length() < 1) {
+            throw new RedirectsParseException(message.get());
+        }
+        return string;
+    }
+
+    public static class ClassTarget {
+        private final String className;
+        private final List<String> usesSets = new ArrayList<>();
+        private final List<TargetMethod> targetMethods = new ArrayList<>();
+
+        ClassTarget(String className) {
+            this.className = className;
+        }
+
+        public void addUsesSet(String usesSet) {
+            this.usesSets.add(usesSet);
+        }
+
+        public void addTarget(TargetMethod targetMethod) {
+            this.targetMethods.add(targetMethod);
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public List<String> getSets() {
+            return Collections.unmodifiableList(usesSets);
+        }
+
+        public List<TargetMethod> getTargetMethods() {
+            return Collections.unmodifiableList(targetMethods);
+        }
+
+        public record TargetMethod(String owner, String returnType, @Nullable String mappingsOwner, String srcMethodName, String dstMethodName, boolean makeSyntheticAccessor) { }
+
+    }
+
+    public static class RedirectSet {
+        private final String name;
+        private final List<TypeRedirect> typeRedirects = new ArrayList<>();
+        private final List<FieldRedirect> fieldRedirects = new ArrayList<>();
+        private final List<MethodRedirect> methodRedirects = new ArrayList<>();
+
+        public RedirectSet(String name) {
+            this.name = name;
+        }
+
+        private void addRedirect(TypeRedirect redirect) {
+            this.typeRedirects.add(redirect);
+        }
+
+        private void addRedirect(FieldRedirect redirect) {
+            this.fieldRedirects.add(redirect);
+        }
+
+        private void addRedirect(MethodRedirect redirect) {
+            this.methodRedirects.add(redirect);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @NotNull public List<TypeRedirect> getTypeRedirects() {
+            return Collections.unmodifiableList(this.typeRedirects);
+        }
+
+        @NotNull public List<FieldRedirect> getFieldRedirects() {
+            return Collections.unmodifiableList(this.fieldRedirects);
+        }
+
+        @NotNull public List<MethodRedirect> getMethodRedirects() {
+            return Collections.unmodifiableList(methodRedirects);
+        }
+
+        public record TypeRedirect(String srcClassName, String dstClassName) { }
+        public record FieldRedirect(String owner, String fieldDesc, @Nullable String mappingsOwner, String srcFieldName, String dstFieldName) { }
+        public record MethodRedirect(String owner, String returnType, @Nullable String mappingsOwner, String srcMethodName, String dstMethodName) { }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/dasm/RedirectsParser.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/transform/dasm/RedirectsParser.java
@@ -1,14 +1,18 @@
 package io.github.opencubicchunks.cubicchunks.mixin.transform.dasm;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.*;
-import java.util.function.Supplier;
 
 public class RedirectsParser {
     private static final String TARGET_METHODS_NAME = "targetMethods";
@@ -34,19 +38,19 @@ public class RedirectsParser {
 
             RedirectSet redirectSet = new RedirectSet(redirectSetName);
 
-            if(!redirectJson.has(TYPE_REDIRECTS_NAME) || !redirectJson.get(TYPE_REDIRECTS_NAME).isJsonObject()) {
+            if (!redirectJson.has(TYPE_REDIRECTS_NAME) || !redirectJson.get(TYPE_REDIRECTS_NAME).isJsonObject()) {
                 throw new RedirectsParseException(String.format("Redirect set has no \"%s\" object", TYPE_REDIRECTS_NAME));
             }
             Set<Map.Entry<String, JsonElement>> typeRedirects = redirectJson.get(TYPE_REDIRECTS_NAME).getAsJsonObject().entrySet();
             parseTypeRedirects(redirectSet, typeRedirects);
 
-            if(!redirectJson.has(FIELD_REDIRECTS_NAME) || !redirectJson.get(FIELD_REDIRECTS_NAME).isJsonObject()) {
+            if (!redirectJson.has(FIELD_REDIRECTS_NAME) || !redirectJson.get(FIELD_REDIRECTS_NAME).isJsonObject()) {
                 throw new RedirectsParseException(String.format("Redirect set has no \"%s\" object", FIELD_REDIRECTS_NAME));
             }
             Set<Map.Entry<String, JsonElement>> fieldRedirects = redirectJson.get(FIELD_REDIRECTS_NAME).getAsJsonObject().entrySet();
             parseFieldRedirects(redirectSet, fieldRedirects);
 
-            if(!redirectJson.has(METHOD_REDIRECTS_NAME) || !redirectJson.get(METHOD_REDIRECTS_NAME).isJsonObject()) {
+            if (!redirectJson.has(METHOD_REDIRECTS_NAME) || !redirectJson.get(METHOD_REDIRECTS_NAME).isJsonObject()) {
                 throw new RedirectsParseException(String.format("Redirect set has no \"%s\" object", METHOD_REDIRECTS_NAME));
             }
             Set<Map.Entry<String, JsonElement>> methodRedirects = redirectJson.get(METHOD_REDIRECTS_NAME).getAsJsonObject().entrySet();
@@ -69,14 +73,14 @@ public class RedirectsParser {
             }
             JsonObject classTargetNode = classTargetElement.getAsJsonObject();
 
-            if(!classTargetNode.has(USE_SETS_NAME)) {
+            if (!classTargetNode.has(USE_SETS_NAME)) {
                 throw new RedirectsParseException(String.format("Class target has no \"%s\" object", USE_SETS_NAME));
             }
 
             ClassTarget classTarget = new ClassTarget(classTargetName);
 
             JsonElement usesSetNameElement = classTargetNode.get(USE_SETS_NAME);
-            if(usesSetNameElement.isJsonPrimitive() && usesSetNameElement.getAsJsonPrimitive().isString()) {
+            if (usesSetNameElement.isJsonPrimitive() && usesSetNameElement.getAsJsonPrimitive().isString()) {
                 //single set
                 classTarget.addUsesSet(throwOnLengthZero(usesSetNameElement.getAsString(), () -> "Specified Class set name has zero length"));
             } else if (usesSetNameElement.isJsonArray()) {
@@ -113,11 +117,11 @@ public class RedirectsParser {
             } else if (value.isJsonObject()) { // target method might want a synthetic accessor
                 JsonObject targetMethodValue = value.getAsJsonObject();
 
-                if(!targetMethodValue.has(DST_NAME)) {
+                if (!targetMethodValue.has(DST_NAME)) {
                     throw new RedirectsParseException(String.format("Target method value does not contain a value for \"%s\". %s", DST_NAME, targetMethodValue));
                 }
                 JsonElement newNameNode = targetMethodValue.get(DST_NAME);
-                if(!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
+                if (!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
                     throw new RedirectsParseException(String.format("Target method value does not contain a valid \"%s\". %s", DST_NAME, newNameNode));
                 }
 
@@ -162,14 +166,14 @@ public class RedirectsParser {
                     srcFieldName,
                     throwOnLengthZero(value.getAsString(), () -> String.format("Field redirect has zero length string value: %s", fieldRedirect))
                 ));
-            } else if(value.isJsonObject()) { // field redirect might contain a mappings owner
+            } else if (value.isJsonObject()) { // field redirect might contain a mappings owner
                 JsonObject fieldRedirectValue = value.getAsJsonObject();
 
-                if(!fieldRedirectValue.has(DST_NAME)) {
+                if (!fieldRedirectValue.has(DST_NAME)) {
                     throw new RedirectsParseException(String.format("Field redirect value does not contain a value for \"%s\". %s", DST_NAME, fieldRedirectValue));
                 }
                 JsonElement newNameNode = fieldRedirectValue.get(DST_NAME);
-                if(!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
+                if (!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
                     throw new RedirectsParseException(String.format("Field redirect value does not contain a valid \"%s\". %s", DST_NAME, newNameNode));
                 }
 
@@ -194,14 +198,14 @@ public class RedirectsParser {
             if (value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
                 String dstMethodName = throwOnLengthZero(value.getAsString(), () -> String.format("Method redirect has zero length value for key %s", methodRedirect));
                 output.addRedirect(new RedirectSet.MethodRedirect(ownerName, returnType, null, srcMethodName, dstMethodName));
-            } else if(value.isJsonObject()) { // method redirect might contain a mappings owner
+            } else if (value.isJsonObject()) { // method redirect might contain a mappings owner
                 JsonObject methodRedirectValue = value.getAsJsonObject();
 
-                if(!methodRedirectValue.has(DST_NAME)) {
+                if (!methodRedirectValue.has(DST_NAME)) {
                     throw new RedirectsParseException(String.format("Method redirect value does not contain a value for \"%s\". %s", DST_NAME, methodRedirectValue));
                 }
                 JsonElement newNameNode = methodRedirectValue.get(DST_NAME);
-                if(!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
+                if (!newNameNode.isJsonPrimitive() || !newNameNode.getAsJsonPrimitive().isString()) {
                     throw new RedirectsParseException(String.format("Method redirect value does not contain a valid \"%s\". %s", DST_NAME, newNameNode));
                 }
 
@@ -217,9 +221,9 @@ public class RedirectsParser {
 
     private boolean getMakeSyntheticAccessorIfPresent(JsonObject redirectElement) throws RedirectsParseException {
         boolean makeSyntheticAccessor = false;
-        if(redirectElement.has(MAKE_SYNTHETIC_ACCESSOR_NAME)) { // synthetic accessor is optional
+        if (redirectElement.has(MAKE_SYNTHETIC_ACCESSOR_NAME)) { // synthetic accessor is optional
             JsonElement syntheticAccessorNode = redirectElement.get(MAKE_SYNTHETIC_ACCESSOR_NAME);
-            if(!syntheticAccessorNode.isJsonPrimitive() || !syntheticAccessorNode.getAsJsonPrimitive().isBoolean()) {
+            if (!syntheticAccessorNode.isJsonPrimitive() || !syntheticAccessorNode.getAsJsonPrimitive().isBoolean()) {
                 throw new RedirectsParseException(String.format("Redirect value does not contain a valid \"%s\". %s", MAKE_SYNTHETIC_ACCESSOR_NAME, syntheticAccessorNode));
             }
             makeSyntheticAccessor = syntheticAccessorNode.getAsBoolean();
@@ -230,12 +234,13 @@ public class RedirectsParser {
     private String getMappingsOwnerIfPresent(JsonObject targetMethodValue)
         throws RedirectsParseException {
         String mappingsOwner = null;
-        if(targetMethodValue.has(MAPPINGS_OWNER_NAME)) { // mappings owner is optional
+        if (targetMethodValue.has(MAPPINGS_OWNER_NAME)) { // mappings owner is optional
             JsonElement mappingsOwnerNode = targetMethodValue.get(MAPPINGS_OWNER_NAME);
-            if(!mappingsOwnerNode.isJsonPrimitive() || !mappingsOwnerNode.getAsJsonPrimitive().isString()) {
+            if (!mappingsOwnerNode.isJsonPrimitive() || !mappingsOwnerNode.getAsJsonPrimitive().isString()) {
                 throw new RedirectsParseException(String.format("Redirect value does not contain a valid \"%s\". %s", MAPPINGS_OWNER_NAME, mappingsOwnerNode));
             }
-            mappingsOwner = throwOnLengthZero(mappingsOwnerNode.getAsString(), () -> String.format("Field redirect has zero length value for %s: %s", MAPPINGS_OWNER_NAME, mappingsOwnerNode));
+            mappingsOwner = throwOnLengthZero(mappingsOwnerNode.getAsString(),
+                () -> String.format("Field redirect has zero length value for %s: %s", MAPPINGS_OWNER_NAME, mappingsOwnerNode));
         }
         return mappingsOwner;
     }

--- a/src/main/resources/dasm/sets/sets.json
+++ b/src/main/resources/dasm/sets/sets.json
@@ -51,5 +51,12 @@
             "net/minecraft/class_1923#method_8324();long": "asLong",
             "net/minecraft/class_1923#method_8331(int, int);long": "asLong"
         }
+    },
+    "chunkMap$DistanceManagerSet": {
+        "typeRedirects": { },
+        "fieldRedirects" : { },
+        "methodRedirects": {
+            "net/minecraft/class_3898#method_17217(long, int, net.minecraft.class_3193, int);net.minecraft.class_3193": "updateCubeScheduling"
+        }
     }
 }

--- a/src/main/resources/dasm/sets/sets.json
+++ b/src/main/resources/dasm/sets/sets.json
@@ -1,0 +1,55 @@
+{
+    "chunkHolderSet": {
+        "typeRedirects": {
+            "net/minecraft/class_1923": "io/github/opencubicchunks/cubicchunks/world/level/CubePos",
+            "net/minecraft/class_2818": "io/github/opencubicchunks/cubicchunks/world/level/chunk/LevelCube",
+            "net/minecraft/class_3193$1": "io/github/opencubicchunks/cubicchunks/server/level/CubeHolder$CubeLoadingError"
+        },
+        "fieldRedirects": {
+            "net/minecraft/class_3898#field_18239;I": "MAX_CUBE_DISTANCE",
+            "net/minecraft/class_3193#field_13864;net/minecraft/class_1923": "cubePos"
+        },
+        "methodRedirects": {
+            "net/minecraft/class_3193#method_14011(int);net.minecraft.class_2806": "getCubeStatus",
+            "net/minecraft/class_3898#method_31417(net.minecraft.class_3193);java.util.concurrent.CompletableFuture": "prepareAccessibleCube",
+            "net/minecraft/class_3898#method_17235(net.minecraft.class_3193);java.util.concurrent.CompletableFuture": "prepareTickingCube",
+            "net/minecraft/class_3898#method_17247(net.minecraft.class_1923);java.util.concurrent.CompletableFuture": "prepareEntityTickingCube",
+            "net/minecraft/class_3898#method_20576(net.minecraft.class_2818);java.util.concurrent.CompletableFuture": "packCubeTicks",
+            "net/minecraft/class_3193$class_3896#method_17209(net.minecraft.class_1923, java.util.function.IntSupplier, int, java.util.function.IntConsumer);void": "onCubeLevelChange"
+        }
+    },
+    "chunkMapSet": {
+        "typeRedirects": {
+            "net/minecraft/class_1923": "io/github/opencubicchunks/cubicchunks/world/level/CubePos",
+            "net/minecraft/class_3900": "io/github/opencubicchunks/cubicchunks/server/level/CubeTaskPriorityQueueSorter"
+        },
+        "fieldRedirects": {
+            "net/minecraft/class_3898#field_17221;it/unimi/dsi/fastutil/longs/LongSet": "cubesToDrop",
+            "net/minecraft/class_3898#field_18807;it/unimi/dsi/fastutil/longs/Long2ObjectLinkedOpenHashMap": "pendingCubeUnloads",
+            "net/minecraft/class_3898#field_17223;net/minecraft/class_3900": "cubeQueueSorter",
+            "net/minecraft/class_3898#field_17213;it/unimi/dsi/fastutil/longs/Long2ObjectLinkedOpenHashMap": "updatingCubeMap",
+            "net/minecraft/class_3898#field_18239;I": "MAX_CUBE_DISTANCE",
+            "net/minecraft/class_3898#field_23786;it/unimi/dsi/fastutil/longs/Long2ByteMap": "cubeTypeCache"
+        },
+        "methodRedirects": {
+            "net/minecraft/class_3898#method_17979(net.minecraft.class_1923);net.minecraft.class_2487": "readCubeNBT",
+            "net/minecraft/class_3898#method_27054(net.minecraft.class_1923);void": "markCubePositionReplaceable",
+            "net/minecraft/class_3898#method_27053(net.minecraft.class_1923, net.minecraft.class_2806$class_2808);byte": "markCubePosition",
+            "net/minecraft/class_1923#method_8324();long": "asLong"
+        }
+    },
+    "naturalSpawnerSet": {
+        "typeRedirects": {
+            "net/minecraft/class_1923": "io/github/opencubicchunks/cubicchunks/world/level/CubePos",
+            "net/minecraft/class_1948$class_5260": "io/github/opencubicchunks/cubicchunks/world/CubicNaturalSpawner$CubeGetter",
+            "net/minecraft/class_2818": "net/minecraft/class_2791"
+        },
+        "fieldRedirects": { },
+        "methodRedirects": {
+            "net/minecraft/class_1948#method_8663(net.minecraft.class_1311, net.minecraft.class_3218, net.minecraft.class_2818, net.minecraft.class_1948$class_5261, net.minecraft.class_1948$class_5259);void": "spawnCategoryForCube",
+            "net/minecraft/class_1948#method_8657(net.minecraft.class_1937, net.minecraft.class_2818);net.minecraft.class_2338": "getRandomPosWithinCube",
+            "net/minecraft/class_1923#method_8324();long": "asLong",
+            "net/minecraft/class_1923#method_8331(int, int);long": "asLong"
+        }
+    }
+}

--- a/src/main/resources/dasm/targets.json
+++ b/src/main/resources/dasm/targets.json
@@ -24,5 +24,11 @@
             "net/minecraft/class_1948#method_27815(int, java.lang.Iterable, net.minecraft.class_1948$class_5260);net.minecraft.class_1948$class_5262": "createCubicState"
         },
         "useSets": "naturalSpawnerSet"
+    },
+    "net/minecraft/class_3898$class_3216": {
+        "targetMethods": {
+            "net/minecraft/class_3204#method_14053(long, int, net.minecraft.class_3193, int);net.minecraft.class_3193": "updateCubeScheduling"
+        },
+        "useSets": "chunkMap$DistanceManagerSet"
     }
 }

--- a/src/main/resources/dasm/targets.json
+++ b/src/main/resources/dasm/targets.json
@@ -1,0 +1,28 @@
+{
+    "net/minecraft/class_3193": {
+        "targetMethods": {
+            "net/minecraft/class_3193#<init>(net.minecraft.class_1923, int, net.minecraft.class_5539, net.minecraft.class_3568, net.minecraft.class_3193$class_3896, net.minecraft.class_3193$class_3897);void": "<init>",
+            "net/minecraft/class_3193#method_14007(net.minecraft.class_3898, java.util.concurrent.Executor);void": "updateCubeFutures"
+        },
+        "useSets": "chunkHolderSet"
+    },
+    "net/minecraft/class_3898": {
+        "targetMethods": {
+            "net/minecraft/class_3898#method_17217(long, int, net.minecraft.class_3193, int);net.minecraft.class_3193": {
+                "newName": "updateCubeScheduling",
+                "makeSyntheticAccessor": true
+            },
+            "net/minecraft/class_3898#method_27055(net.minecraft.class_1923);boolean": "isExistingCubeFull"
+        },
+        "useSets": "chunkMapSet"
+    },
+    "net/minecraft/class_1948": {
+        "targetMethods": {
+            "net/minecraft/class_1948#method_27821(net.minecraft.class_3218, net.minecraft.class_2818, net.minecraft.class_1948$class_5262, boolean, boolean, boolean);void": "spawnForCube",
+            "net/minecraft/class_1948#method_8663(net.minecraft.class_1311, net.minecraft.class_3218, net.minecraft.class_2818, net.minecraft.class_1948$class_5261, net.minecraft.class_1948$class_5259);void": "spawnCategoryForCube",
+            "net/minecraft/class_1948#method_24933(net.minecraft.class_3218, net.minecraft.class_2791, net.minecraft.class_2338$class_2339, double);boolean": "isRightDistanceToPlayerAndSpawnPointForCube",
+            "net/minecraft/class_1948#method_27815(int, java.lang.Iterable, net.minecraft.class_1948$class_5260);net.minecraft.class_1948$class_5262": "createCubicState"
+        },
+        "useSets": "naturalSpawnerSet"
+    }
+}


### PR DESCRIPTION
Currently, there is only one `set.json` and one `target.json`, though that can be fixed easily later

Also if someone can explain the `ChunkMap$DistanceManager` transformation that'd be great. It appears to target `DistanceManager` inherited methods on the subclass, is this correct?